### PR TITLE
계단수와 컬러링북 #홍기

### DIFF
--- a/honggi/code/week15_백준_계단수.java
+++ b/honggi/code/week15_백준_계단수.java
@@ -1,0 +1,66 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+    /*
+        풀이 참고 - https://gose-kose.tistory.com/107
+        계단 수 - 인접한 모든 자리 차이 1
+
+        dp와 비트마스킹을 이용한 문제
+        3차원 배열을 사용, dp[자리수][숫자][숫자에 포함된 수]
+        (bit masking, 1023 -> 1111111111, 0부터 9까지 모든 수가 포함됨을 의미)
+
+        dp[2][3][(1100)]
+        = 2자리 수에 3이 오면서 (2,3)을 사용한 수
+        = 23, 43
+
+        계단 수에 적용 -> i 자리에 0~9중 하나인 수 j가 왔을 때, 비트마스킹을 통해 0~9의 숫자를 방문처리
+        if j == 1 : dp[i][j][k | 1 << j] += dp[n-1][i+1][k]
+        if j == 9 : dp[i][j][k | 1 << j] += dp[n-1][i-1][k]
+        else      : dp[i][j][k | 1 << j] += dp[n-1][i-1][k] + dp[n-1][i+1][k]
+
+     */
+    static long[][][] dp;
+    static int divideN = 1_000_000_000;
+    static int bit = 1 << 10;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        dp = new long[n+1][10][bit];
+        if (n < 10){
+            System.out.println(0);
+        } else {
+            System.out.println(countStair(n));
+        }
+    }
+
+    private static long countStair(int digit) {
+        // 첫 번째 자리에 올 수 있는 수 = 1~9
+        for (int i = 1; i < 10; i++) {
+            dp[1][i][1 << i] = 1;
+        }
+
+        for (int i = 2; i <= digit; i++) {
+            for (int j = 0; j < 10; j++) {
+                for (int k = 0; k < bit; k++) {
+                    int Bit = k | (1 << j); // k수에 숫자 j가 포함되어있음을 비트연산으로 계산 (숫자 j를 포함한 수가 됨)
+
+                    if (j == 0 || j == 9){
+                        dp[i][j][Bit] = j == 0 ? (dp[i][j][Bit] + dp[i-1][j+1][k]) % divideN
+                            : (dp[i][j][Bit] + dp[i-1][j-1][k]) % divideN;
+                    } else {
+                        dp[i][j][Bit] = (dp[i][j][Bit] + dp[i-1][j-1][k] + dp[i-1][j+1][k]) % divideN;
+                    }
+                }
+            }
+        }
+
+        // n자리 수에 대해서, 0부터 9까지 숫자로 끝나는 숫자 중 0~9가 모두 포함된 수를 모두 더함
+        long result = 0;
+        for (int i = 0; i < 10; i++) {
+            result = (result + dp[digit][i][bit-1]) % divideN;
+        }
+        return result;
+    }
+}

--- a/honggi/code/week15_프로그래머스_카카오프렌즈컬러링북.java
+++ b/honggi/code/week15_프로그래머스_카카오프렌즈컬러링북.java
@@ -1,0 +1,54 @@
+import java.util.HashSet;
+
+class Solution {
+    
+    /*
+        사람들의 질문사항을 보니 이 문제는 체점 관련하여 전역변수를 solution 안에서
+        모두 초기화해야 한다는 에로사항이 있네요..!
+
+        풀이 방법
+        모든 셀을 순회하면서 방문하지 않은 셀들을 방문하여 상하좌우를 dfs를 사용하여 탐색, 
+        같은 원소(같은 색 영역)의 영역의 넓이를 체크하고, 그 중 가장 큰 영역의 크기를 구함.
+
+    */
+
+    int[][] xy = new int[][]{{0,-1}, {0,1}, {-1,0}, {1,0}};;
+    int rowL, colL, max;
+    boolean[][] visited;
+    int[][] p;
+    public int[] solution(int m, int n, int[][] picture) {
+        rowL = m;
+        colL = n;
+        max = 0;
+        visited = new boolean[m][n];
+        p = picture;
+        int areaCount = 0;
+                
+        for (int i = 0; i<rowL; i++){
+            for (int j = 0; j<colL; j++){
+                if (!visited[i][j] && p[i][j] > 0){
+                    max = Math.max(dfs(i,j,p[i][j]), max);
+                    areaCount++;
+                }
+            }
+        }
+                
+        return new int[]{areaCount, max};
+    }
+    
+    public int dfs(int m, int n, int type){
+        if (m < 0 || n < 0 || m == rowL || n == colL || type != p[m][n]){
+            return 0;
+        }
+        
+        int area = 0;
+        if (!visited[m][n]){
+            visited[m][n] = true;
+            area++;
+            for (int i = 0; i<4; i++){
+                area += dfs(m + xy[i][0], n + xy[i][1], type);
+            }
+        }
+        return area;
+    }
+}


### PR DESCRIPTION
Issue num : #114 (week 15 - Common problem solution)

## 💡 PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our <a href="https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit">guidelines</a>
- [x] Reviewers
- [x] Assignees
- [x] Link Issue number

---

## 💡 PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Upload a solved problem
- [ ] Upload a blog

<br>

---

## ✏︎ What is the new behavior?
<!-- 해당 주차에 진행한 내용 정리 -->
Issue Number: Closes #114 

Context
[7/23]
- 카카오 프렌즈 컬러링북 풀이완료
- 계단 수 풀이중

[8/6]
- 메모이제이션을 적용한 계단 수 풀이중..

[8/9]
- 메모이제이션과 비트마스킹을 활용한 풀이 (도표 풀이로는 해답이 나오지 않아 결국 블로그의 힌트를 얻어 풀이했습니다..😂)
<img width="1158" alt="image" src="https://github.com/techeer-sv/Do-It-Algorithm-Study/assets/33611439/ea1e963d-785b-489d-bcd6-1e7a1e78104c">

- 1자리 수 부터 n자리 수까지 bottom-up 방식을 통해 요구사항에 충족하는 값을 구함
- 0~9까지 모든 수가 포함되어있는지 여부를 판단하는 방법 -> 비트마스킹 활용
  - 0~9까지의 총 10개에 해당하는 숫자를 bit를 사용하여 포함여부를 판단
  - 1111111111(1023)인 경우, 0~9가 모두 포함되어있다고 판단이 가능 -> 이를 통해 0~9가 모두 포함된 계단수를 구하기
 
<br>

3차원 배열 dp의 의미 : dp[자리 수][자리 수에 오는 숫자][방문한 숫자]
ex) dp[2][3][(1100)] -> 2자리수에 3이 올 수 있는 경우의 수 중, 2와 3이 포함되는 경우, 23과 43에 해당하며,
이는 dp[1][2][(100)] + dp[1][4][(1000)]의 합산으로 볼 수 있다
=> 점화식 : dp[i][j][k | 1 << j] += dp[i-1][j-1][k] + dp[i-1][j+1][k]
